### PR TITLE
Disruption reason has a maximum width

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -58,6 +58,14 @@ td strong {
   display: block;
 }
 
+.reason {
+  max-height: 30px;
+  max-width: 1000px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 footer {
   font-size: 16px;
   margin-left: 36px;

--- a/views/index.haml
+++ b/views/index.haml
@@ -20,7 +20,8 @@
               %td
                 %strong
                   = status[:severity]
-                = status[:reason] unless status[:reason].empty?
+                .reason
+                  = status[:reason] unless status[:reason].empty?
 
     %footer
       %p.updated


### PR DESCRIPTION
Sometimes, the reason for a disruption is a few paragraphs long. Displaying it in its entirety breaks the layout, and is not particularly useful.