### PR TITLE
(Fix) Replace hardcoded app name

### DIFF
--- a/container_definitions/app.json.tpl
+++ b/container_definitions/app.json.tpl
@@ -18,7 +18,7 @@
     "environment": [
       {
         "name": "SSM_PATH_SUFFIX",
-        "value": "app"
+        "value": "${container_name}"
       }
     ]
   }

--- a/kms.tf
+++ b/kms.tf
@@ -1,9 +1,9 @@
 resource "aws_kms_key" "app_ssm" {
-  description             = "app SSM key ${terraform.workspace}"
+  description             = "${local.app_name} SSM key ${terraform.workspace}"
   deletion_window_in_days = 10
 }
 
 resource "aws_kms_alias" "app_ssm" {
-  name          = "alias/app-ssm-${terraform.workspace}"
+  name          = "alias/${local.app_name}-ssm-${terraform.workspace}"
   target_key_id = "${aws_kms_key.app_ssm.key_id}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,9 @@
 locals {
+  app_name = "tfl"
+
   app_github_owner = "dxw"
   app_github_repo  = "tfl-dashboard"
-  app_service_name = "app-tfl-dashboard-${var.environment}"
+  app_service_name = "${local.app_name}-${var.environment}"
 
   app_container_entrypoint = ["./docker-entrypoint.sh"]
   app_container_command    = ["bundle", "exec", "puma", "-p", "5000"]


### PR DESCRIPTION
* Allows setting the name in `local.app_name`
* Should be unique within the same AWS account